### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -176,7 +176,7 @@
             <!-- 从SDCard读取数据权限 -->
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
             <!-- 相机权限 -->
-            <uses-permission android:name="android.permission.CAMERA"/>
+            <uses-permission android:name="android.permission.CAMERA" android:required="false"/>  
 
         </config-file>
 


### PR DESCRIPTION
添加android:required="false"属性，解决与二维码扫描QR Scanner，相机权限冲突，build不了问题